### PR TITLE
update the durable property while declaring queue in consumer.go

### DIFF
--- a/messaging/rabbitmq/applications/consumer/consumer.go
+++ b/messaging/rabbitmq/applications/consumer/consumer.go
@@ -33,7 +33,7 @@ func consume() {
 
 	q, err := ch.QueueDeclare(
 		"publisher", // name
-		false,   // durable
+		true,   // durable
 		false,   // delete when unused
 		false,   // exclusive
 		false,   // no-wait


### PR DESCRIPTION
Getting the below error. After making it true from false worked for me.

FATA[0000] Failed to declare a queue: Exception (406) Reason: "PRECONDITION_FAILED - inequivalent arg 'durable' for queue 'publisher' in vhost '/': received 'false' but current is 'true'"

For publishers and consumers, it should be the same.