### PR TITLE
Removed link to specific release tag

### DIFF
--- a/kubernetes/servicemesh/linkerd/readme.md
+++ b/kubernetes/servicemesh/linkerd/readme.md
@@ -98,7 +98,7 @@ linkerd-control-plane   Ready    master   26m   v1.19.1
 Lets download the `linkerd` command line tool <br/>
 I grabbed the `edge-20.10.1` release using `curl`
 
-You can go to the [releases](https://github.com/linkerd/linkerd2/releases/tag/edge-20.10.1) page to get it
+You can go to the [releases](https://github.com/linkerd/linkerd2/releases/) page to get it
 
 ```
 curl -L -o linkerd https://github.com/linkerd/linkerd2/releases/download/edge-20.10.1/linkerd2-cli-edge-20.10.1-linux-amd64 


### PR DESCRIPTION
Previously it was a link to specific release (edge-20.10.1), but now to make it future-proof, I have modified the link to the main page of releases, so a user can see all the latest releases.

Otherwise while performing `linkerd check --pre` user will get an warning about using the old version of linkerd CLI.

![2021-07-08_07-26](https://user-images.githubusercontent.com/20947380/124850203-d3ca5e00-dfbd-11eb-8764-162664ff1fdd.png)
