### PR TITLE
Fix error: failed to find unique target for patch apps_v1_Deployment|…

### DIFF
--- a/kubernetes/kustomize/environments/development/replica_count.yaml
+++ b/kubernetes/kustomize/environments/development/replica_count.yaml
@@ -2,5 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-deploy
+  namespace: example
 spec:
   replicas: 4

--- a/kubernetes/kustomize/environments/production/env.yaml
+++ b/kubernetes/kustomize/environments/production/env.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-deploy
+  namespace: example  
 spec:
   template:
     spec:

--- a/kubernetes/kustomize/environments/production/replica_count.yaml
+++ b/kubernetes/kustomize/environments/production/replica_count.yaml
@@ -2,5 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-deploy
+  namespace: example  
 spec:
   replicas: 6

--- a/kubernetes/kustomize/environments/production/resource_limits.yaml
+++ b/kubernetes/kustomize/environments/production/resource_limits.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-deploy
+  namespace: example  
 spec:
   template:
     spec:


### PR DESCRIPTION
Hi Marcel, first thank you for the great sharing!

With kubectl 1.22.0,I ran into: `error: no matches for Id apps_v1_Deployment|~X|example-deploy; failed to find unique target for patch apps_v1_Deployment|example-deploy`

After specifying namespace, the error disappeared. Hope this is a valid fix :).