### PR TITLE
Remove extra code quotes

### DIFF
--- a/hashicorp/vault/example-apps/dynamic-postgresql/readme.md
+++ b/hashicorp/vault/example-apps/dynamic-postgresql/readme.md
@@ -13,7 +13,6 @@ kubectl -n postgres exec -it <podname> bash
 psql --username=postgresadmin postgresdb
 ```
 
-```
 Enable the database engine
 
 ```


### PR DESCRIPTION
Removed an extra set of code quotes that caused headers to appear as a code block and code to appear as plain text.