### PR TITLE
Avoid fixed namespace

### DIFF
--- a/storage/redis/kubernetes/sentinel/sentinel-statefulset.yaml
+++ b/storage/redis/kubernetes/sentinel/sentinel-statefulset.yaml
@@ -20,7 +20,7 @@ spec:
         args:
           - |
             REDIS_PASSWORD=a-very-complex-password-here
-            nodes=redis-0.redis.redis.svc.cluster.local,redis-1.redis.redis.svc.cluster.local,redis-2.redis.redis.svc.cluster.local
+            nodes=redis-0.redis,redis-1.redis,redis-2.redis
 
             for i in ${nodes//,/ }
             do


### PR DESCRIPTION
With the current setup, Sentinel only works if everything is running in the tutorial's default namespace 'redis'. Applying this fix allows the solution to run in any namespace as long as Redis and Sentinel is running in the same namespace.

The trick is to use relative DNS naming which is fully supported by Kubernetes.