### PR TITLE
Update cluster-role.yaml

### DIFF
--- a/kubernetes/ingress/controller/nginx/cluster-role.yaml
+++ b/kubernetes/ingress/controller/nginx/cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: nginx-ingress-clusterrole


### PR DESCRIPTION
Update in rbac
The rbac.authorization.k8s.io/v1beta1 API version of ClusterRole, ClusterRoleBinding, Role, and RoleBinding is no longer served as of v1.22.