### PR TITLE
docker-compose examples only worked with this fluentd

### DIFF
--- a/monitoring/logging/fluentd/introduction/docker-compose.yaml
+++ b/monitoring/logging/fluentd/introduction/docker-compose.yaml
@@ -3,9 +3,7 @@ services:
   fluentd:
     container_name: fluentd
     user: root
-    build:
-      context: .
-    image: fluentd
+    image: fluent/fluentd:v1.11-debian
     volumes:
     - /var/lib/docker/containers:/fluentd/log/containers # Example: Reading docker logs
     - ./file:/fluentd/log/files/ #Example: Reading logs from a file


### PR DESCRIPTION
Hi Marcel,

Thank you so much for all your videos! They are awesome.


Following this video: https://www.youtube.com/watch?v=Gp0-7oVOtPw&t=847s ,


-  I wasn't able to get the docker-compose examples in the https://github.com/marcel-dempers/docker-development-youtube-series/tree/master/monitoring/logging/fluentd/introduction folder working unless I changed the fluentd to be the same as the basic-demo folder
- I also tried keeping https://github.com/marcel-dempers/docker-development-youtube-series/blob/master/monitoring/logging/fluentd/introduction/docker-compose.yaml unchanged and running 'docker-compose build' (not in the instructions), but that didn't work either...the build actually fails
- also, I am on Windows 10 with WSL2 with Docker Desktop, and I couldn't even run the basic-demo because of a git configuration I was missing : "git config --global core.autocrlf false".  Without the previous command, running the basic-demo would fail because /app/app.sh could not be found in the alpine container. I found this article which helped me: https://unix.stackexchange.com/questions/433444/cant-run-script-file-in-docker-no-such-file-or-directory .