### PR TITLE
fix typo

### DIFF
--- a/messaging/rabbitmq/kubernetes/readme.md
+++ b/messaging/rabbitmq/kubernetes/readme.md
@@ -45,7 +45,7 @@ Password: `guest` <br/>
 cd messaging\rabbitmq\applications\publisher
 docker build . -t aimvector/rabbitmq-publisher:v1.0.0
 
-kubectl apply -f rabbits deployment.yaml
+kubectl apply -n rabbits -f deployment.yaml
 ```
 
 # Automatic Synchronization


### PR DESCRIPTION
I am follow along with [Youtube](https://youtu.be/_lpDfMkxccc?t=927) video, and I found potential typo in the readme file.

**`Original`**
```
kubectl apply -f rabbits deployment.yaml
```
**`Fixed`**
```
kubectl apply -n rabbits -f deployment.yaml
```

In the video, the author use fixed kubectl command in timestamp of 15:27, I believe the author forgot to change in the readme file. The original kubectl will cause error because the deployment.yml should be apply in namespace of rabbits.