### PR TITLE
add 'include_timestamp true' in the elastic part of the configmap to …

### DIFF
--- a/monitoring/logging/fluentd/kubernetes/counter-err.yaml
+++ b/monitoring/logging/fluentd/kubernetes/counter-err.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: counter-err
+  labels:
+    app: counter-err
+    version: v1.2
+spec:
+  containers:
+  - name: count
+    image: busybox
+    args: [/bin/sh, -c,
+            'i=0; RANDOM=$$; while true; do R=$(($RANDOM%100)); echo "loop:$i  value:$R"; if [ $R -gt 80 ]; then echo "Warning:$R too high" 1>&2; fi; i=$((i+1)); sleep 1; done']

--- a/monitoring/logging/fluentd/kubernetes/dockerfiles/dockerfile
+++ b/monitoring/logging/fluentd/kubernetes/dockerfiles/dockerfile
@@ -33,6 +33,8 @@ RUN touch /fluentd/etc/disable.conf
 # Copy plugins
 COPY plugins /fluentd/plugins/
 COPY entrypoint.sh /fluentd/entrypoint.sh
+# chmod needed in full Linux env :)
+RUN chmod 755 /fluentd/entrypoint.sh
 
 # Environment variables
 ENV FLUENTD_OPT=""

--- a/monitoring/logging/fluentd/kubernetes/fluentd-configmap.yaml
+++ b/monitoring/logging/fluentd/kubernetes/fluentd-configmap.yaml
@@ -51,7 +51,7 @@ data:
       <parse>
         @type kubernetes
         @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
+        time_format "%Y-%m-%dT%H:%M:%S.%NZ"
       </parse>
     </source>
 
@@ -78,4 +78,5 @@ data:
       port "#{ENV['FLUENT_ELASTICSEARCH_PORT'] || '9200'}"
       index_name fluentd-k8s
       type_name fluentd
+      include_timestamp true
     </match>


### PR DESCRIPTION
Hi Marcel,

Beforehand, this is a great chance of thanking you for all your great work ! In my Kubernetes leanring path, your publications are of utmost help !

I started to search solutions to concentrates Kubernetes Pods Logs, and, as usual, your tutorial was precise and easy to follow.

I encountered two troubles:

One was very straigthforward : as I work on "full Linux" environments, I missed a 'chmod' in the Dockerfile (I wouln'd write for this small thing !)
I lost a lot of time on the second trouble, and i saw that this didn't work for you either, in the youtube video : The logs records in elasticsearch were missing the timestamps, and logs witout timestamp are nearly of no use. 

The solution is really simple (when you find it :) ) :  one tag was missing in the elstic-fluent.conf part of the configmap : 
`include_timestamp true`

As a 'bonus' (but you may like it or not), I added a slightly modified version of counter.yaml, named counter-err.yaml who put also 'randomly' data on the stderr.

I hope that these changes suits you.

Cheers,

Pascal (from France)