### PR TITLE
fix: docker build failing because of deprecated go version

### DIFF
--- a/messaging/rabbitmq/applications/consumer/dockerfile
+++ b/messaging/rabbitmq/applications/consumer/dockerfile
@@ -1,16 +1,17 @@
-FROM golang:1.14-alpine as build
+FROM golang:1.16-alpine as build
 
 RUN apk add --no-cache git
 
 WORKDIR /src 
 
-RUN go get github.com/sirupsen/logrus
-RUN go get github.com/streadway/amqp
+COPY go.mod ./
+COPY go.sum ./
 
-COPY consumer.go /src 
+RUN go mod download
+
+COPY consumer.go ./
 
 RUN go build consumer.go
-
 
 FROM alpine as runtime
 

--- a/messaging/rabbitmq/applications/consumer/go.mod
+++ b/messaging/rabbitmq/applications/consumer/go.mod
@@ -1,0 +1,8 @@
+module consumerMod
+
+go 1.16
+
+require (
+	github.com/sirupsen/logrus v1.6.0
+	github.com/streadway/amqp v1.0.0
+)

--- a/messaging/rabbitmq/applications/consumer/go.sum
+++ b/messaging/rabbitmq/applications/consumer/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
+github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
+github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/messaging/rabbitmq/applications/publisher/dockerfile
+++ b/messaging/rabbitmq/applications/publisher/dockerfile
@@ -1,14 +1,15 @@
-FROM golang:1.14-alpine as build
+FROM golang:1.16-alpine as build
 
 RUN apk add --no-cache git
 
 WORKDIR /src 
 
-RUN go get github.com/julienschmidt/httprouter
-RUN go get github.com/sirupsen/logrus
-RUN go get github.com/streadway/amqp
+COPY go.mod ./
+COPY go.sum ./
 
-COPY publisher.go /src 
+RUN go mod download
+
+COPY publisher.go ./
 
 RUN go build publisher.go
 

--- a/messaging/rabbitmq/applications/publisher/go.mod
+++ b/messaging/rabbitmq/applications/publisher/go.mod
@@ -1,0 +1,9 @@
+module publisherMod
+
+go 1.16
+
+require (
+	github.com/julienschmidt/httprouter v1.3.0
+	github.com/sirupsen/logrus v1.6.0
+	github.com/streadway/amqp v1.0.0
+)

--- a/messaging/rabbitmq/applications/publisher/go.sum
+++ b/messaging/rabbitmq/applications/publisher/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
+github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
+github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
When following the video I noticed the docker building of both apps (consumer and publisher) didn't work. So I readapted the dockerfiles and included the *.mod and *.sum files that are required in most modern versions of go. Tested both changes before commiting successfully.