### PR TITLE
Fixing Redis Kubernetes

### DIFF
--- a/storage/redis/kubernetes/redis/redis-configmap.yaml
+++ b/storage/redis/kubernetes/redis/redis-configmap.yaml
@@ -10,9 +10,13 @@ data:
     # started with the file path as first argument:
     #
     # ./redis-server /path/to/redis.conf
-    #slaveof redis-master-0.redis-master.redis.svc.cluster.local 6379
+
+    # This will be set by our Init Container
+    # replicaof redis-master-0.redis-master.redis.svc.cluster.local 6379
+
     masterauth a-very-complex-password-here
     requirepass a-very-complex-password-here
+
     # Note on units: when memory size is needed, it is possible to specify
     # it in the usual form of 1k 5GB 4M and so forth:
     #
@@ -32,7 +36,7 @@ data:
     # to customize a few per-server settings.  Include files can include
     # other files, so use this wisely.
     #
-    # Notice option "include" won't be rewritten by command "CONFIG REWRITE"
+    # Note that option "include" won't be rewritten by command "CONFIG REWRITE"
     # from admin or Redis Sentinel. Since Redis always uses the last processed
     # line as value of a configuration directive, you'd better put includes
     # at the beginning of this file to avoid overwriting config change at runtime.
@@ -40,8 +44,17 @@ data:
     # If instead you are interested in using includes to override configuration
     # options, it is better to use include as the last line.
     #
+    # Included paths may contain wildcards. All files matching the wildcards will
+    # be included in alphabetical order.
+    # Note that if an include path contains a wildcards but no files match it when
+    # the server is started, the include statement will be ignored and no error will
+    # be emitted.  It is safe, therefore, to include wildcard files from empty
+    # directories.
+    #
     # include /path/to/local.conf
     # include /path/to/other.conf
+    # include /path/to/fragments/*.conf
+    #
 
     ################################## MODULES #####################################
 
@@ -54,46 +67,83 @@ data:
     ################################## NETWORK #####################################
 
     # By default, if no "bind" configuration directive is specified, Redis listens
-    # for connections from all the network interfaces available on the server.
+    # for connections from all available network interfaces on the host machine.
     # It is possible to listen to just one or multiple selected interfaces using
     # the "bind" configuration directive, followed by one or more IP addresses.
+    # Each address can be prefixed by "-", which means that redis will not fail to
+    # start if the address is not available. Being not available only refers to
+    # addresses that does not correspond to any network interface. Addresses that
+    # are already in use will always fail, and unsupported protocols will always BE
+    # silently skipped.
     #
     # Examples:
     #
-    # bind 192.168.1.100 10.0.0.1
-    # bind 127.0.0.1 ::1
+    # bind 192.168.1.100 10.0.0.1     # listens on two specific IPv4 addresses
+    # bind 127.0.0.1 ::1              # listens on loopback IPv4 and IPv6
+    # bind * -::*                     # like the default, all available interfaces
     #
     # ~~~ WARNING ~~~ If the computer running Redis is directly exposed to the
     # internet, binding to all the interfaces is dangerous and will expose the
     # instance to everybody on the internet. So by default we uncomment the
-    # following bind directive, that will force Redis to listen only into
-    # the IPv4 loopback interface address (this means Redis will be able to
-    # accept connections only from clients running into the same computer it
-    # is running).
+    # following bind directive, that will force Redis to listen only on the
+    # IPv4 and IPv6 (if available) loopback interface addresses (this means Redis
+    # will only be able to accept client connections from the same host that it is
+    # running on).
     #
     # IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
-    # JUST COMMENT THE FOLLOWING LINE.
+    # COMMENT OUT THE FOLLOWING LINE.
+    #
+    # You will also need to set a password unless you explicitly disable protected
+    # mode.
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     bind 0.0.0.0
+
+    # By default, outgoing connections (from replica to master, from Sentinel to
+    # instances, cluster bus, etc.) are not bound to a specific local address. In
+    # most cases, this means the operating system will handle that based on routing
+    # and the interface through which the connection goes out.
+    #
+    # Using bind-source-addr it is possible to configure a specific address to bind
+    # to, which may also affect how the connection gets routed.
+    #
+    # Example:
+    #
+    # bind-source-addr 10.0.0.1
 
     # Protected mode is a layer of security protection, in order to avoid that
     # Redis instances left open on the internet are accessed and exploited.
     #
-    # When protected mode is on and if:
-    #
-    # 1) The server is not binding explicitly to a set of addresses using the
-    #    "bind" directive.
-    # 2) No password is configured.
-    #
-    # The server only accepts connections from clients connecting from the
-    # IPv4 and IPv6 loopback addresses 127.0.0.1 and ::1, and from Unix domain
-    # sockets.
+    # When protected mode is on and the default user has no password, the server
+    # only accepts local connections from the IPv4 address (127.0.0.1), IPv6 address
+    # (::1) or Unix domain sockets.
     #
     # By default protected mode is enabled. You should disable it only if
     # you are sure you want clients from other hosts to connect to Redis
-    # even if no authentication is configured, nor a specific set of interfaces
-    # are explicitly listed using the "bind" directive.
+    # even if no authentication is configured.
     protected-mode no
+
+    # Redis uses default hardened security configuration directives to reduce the
+    # attack surface on innocent users. Therefore, several sensitive configuration
+    # directives are immutable, and some potentially-dangerous commands are blocked.
+    #
+    # Configuration directives that control files that Redis writes to (e.g., 'dir'
+    # and 'dbfilename') and that aren't usually modified during runtime
+    # are protected by making them immutable.
+    #
+    # Commands that can increase the attack surface of Redis and that aren't usually
+    # called by users are blocked by default.
+    #
+    # These can be exposed to either all connections or just local ones by setting
+    # each of the configs listed below to either of these values:
+    #
+    # no    - Block for any connection (remain immutable)
+    # yes   - Allow for any connection (no protection)
+    # local - Allow only for local connections. Ones originating from the
+    #         IPv4 address (127.0.0.1), IPv6 address (::1) or Unix domain sockets.
+    #
+    # enable-protected-configs no
+    # enable-debug-command no
+    # enable-module-command no
 
     # Accept connections on the specified port, default is 6379 (IANA #815344).
     # If port 0 is specified Redis will not listen on a TCP socket.
@@ -101,8 +151,8 @@ data:
 
     # TCP listen() backlog.
     #
-    # In high requests-per-second environments you need an high backlog in order
-    # to avoid slow clients connections issues. Note that the Linux kernel
+    # In high requests-per-second environments you need a high backlog in order
+    # to avoid slow clients connection issues. Note that the Linux kernel
     # will silently truncate it to the value of /proc/sys/net/core/somaxconn so
     # make sure to raise both the value of somaxconn and tcp_max_syn_backlog
     # in order to get the desired effect.
@@ -114,7 +164,7 @@ data:
     # incoming connections. There is no default, so Redis will not listen
     # on a unix socket when not specified.
     #
-    # unixsocket /tmp/redis.sock
+    # unixsocket /run/redis.sock
     # unixsocketperm 700
 
     # Close the connection after a client is idle for N seconds (0 to disable)
@@ -126,8 +176,8 @@ data:
     # of communication. This is useful for two reasons:
     #
     # 1) Detect dead peers.
-    # 2) Take the connection alive from the point of view of network
-    #    equipment in the middle.
+    # 2) Force network equipment in the middle to consider the connection to be
+    #    alive.
     #
     # On Linux, the specified value (in seconds) is the period used to send ACKs.
     # Note that to close the connection the double of the time is needed.
@@ -136,6 +186,16 @@ data:
     # A reasonable value for this option is 300 seconds, which is the new
     # Redis default starting with Redis 3.2.1.
     tcp-keepalive 300
+
+    # Apply OS-specific mechanism to mark the listening socket with the specified
+    # ID, to support advanced routing and filtering capabilities.
+    #
+    # On Linux, the ID represents a connection mark.
+    # On FreeBSD, the ID represents a socket cookie ID.
+    # On OpenBSD, the ID represents a route table ID.
+    #
+    # The default value is 0, which implies no marking is required.
+    # socket-mark-id 0
 
     ################################# TLS/SSL #####################################
 
@@ -152,8 +212,32 @@ data:
     #
     # tls-cert-file redis.crt
     # tls-key-file redis.key
+    #
+    # If the key file is encrypted using a passphrase, it can be included here
+    # as well.
+    #
+    # tls-key-file-pass secret
 
-    # Configure a DH parameters file to enable Diffie-Hellman (DH) key exchange:
+    # Normally Redis uses the same certificate for both server functions (accepting
+    # connections) and client functions (replicating from a master, establishing
+    # cluster bus connections, etc.).
+    #
+    # Sometimes certificates are issued with attributes that designate them as
+    # client-only or server-only certificates. In that case it may be desired to use
+    # different certificates for incoming (server) and outgoing (client)
+    # connections. To do that, use the following directives:
+    #
+    # tls-client-cert-file client.crt
+    # tls-client-key-file client.key
+    #
+    # If the key file is encrypted using a passphrase, it can be included here
+    # as well.
+    #
+    # tls-client-key-file-pass secret
+
+    # Configure a DH parameters file to enable Diffie-Hellman (DH) key exchange,
+    # required by older versions of OpenSSL (<3.0). Newer versions do not require
+    # this configuration and recommend against it.
     #
     # tls-dh-params-file redis.dh
 
@@ -167,9 +251,12 @@ data:
     # By default, clients (including replica servers) on a TLS port are required
     # to authenticate using valid client side certificates.
     #
-    # It is possible to disable authentication using this directive.
+    # If "no" is specified, client certificates are not required and not accepted.
+    # If "optional" is specified, client certificates are accepted and must be
+    # valid if provided, but are not required.
     #
     # tls-auth-clients no
+    # tls-auth-clients optional
 
     # By default, a Redis replica does not attempt to establish a TLS connection
     # with its master.
@@ -183,9 +270,12 @@ data:
     #
     # tls-cluster yes
 
-    # Explicitly specify TLS versions to support. Allowed values are case insensitive
-    # and include "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" (OpenSSL >= 1.1.1) or
-    # any combination. To enable only TLSv1.2 and TLSv1.3, use:
+    # By default, only TLSv1.2 and TLSv1.3 are enabled and it is highly recommended
+    # that older formally deprecated versions are kept disabled to reduce the attack surface.
+    # You can explicitly specify TLS versions to support.
+    # Allowed values are case insensitive and include "TLSv1", "TLSv1.1", "TLSv1.2",
+    # "TLSv1.3" (OpenSSL >= 1.1.1) or any combination.
+    # To enable only TLSv1.2 and TLSv1.3, use:
     #
     # tls-protocols "TLSv1.2 TLSv1.3"
 
@@ -227,18 +317,26 @@ data:
 
     # By default Redis does not run as a daemon. Use 'yes' if you need it.
     # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
+    # When Redis is supervised by upstart or systemd, this parameter has no impact.
     daemonize no
 
     # If you run Redis from upstart or systemd, Redis can interact with your
     # supervision tree. Options:
     #   supervised no      - no supervision interaction
     #   supervised upstart - signal upstart by putting Redis into SIGSTOP mode
+    #                        requires "expect stop" in your upstart job config
     #   supervised systemd - signal systemd by writing READY=1 to $NOTIFY_SOCKET
+    #                        on startup, and updating Redis status on a regular
+    #                        basis.
     #   supervised auto    - detect upstart or systemd method based on
     #                        UPSTART_JOB or NOTIFY_SOCKET environment variables
     # Note: these supervision methods only signal "process is ready."
-    #       They do not enable continuous liveness pings back to your supervisor.
-    supervised no
+    #       They do not enable continuous pings back to your supervisor.
+    #
+    # The default is "no". To run under upstart/systemd, you can simply uncomment
+    # the line below:
+    #
+    # supervised auto
 
     # If a pid file is specified, Redis writes it where specified at startup
     # and removes it at exit.
@@ -249,7 +347,10 @@ data:
     #
     # Creating a pid file is best effort: if Redis is not able to create it
     # nothing bad happens, the server will start and run normally.
-    pidfile "/var/run/redis_6379.pid"
+    #
+    # Note that on modern Linux systems "/run/redis.pid" is more conforming
+    # and should be used instead.
+    pidfile /var/run/redis_6379.pid
 
     # Specify the server verbosity level.
     # This can be one of:
@@ -274,44 +375,76 @@ data:
     # Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
     # syslog-facility local0
 
+    # To disable the built in crash log, which will possibly produce cleaner core
+    # dumps when they are needed, uncomment the following:
+    #
+    # crash-log-enabled no
+
+    # To disable the fast memory check that's run as part of the crash log, which
+    # will possibly let redis terminate sooner, uncomment the following:
+    #
+    # crash-memcheck-enabled no
+
     # Set the number of databases. The default database is DB 0, you can select
     # a different one on a per-connection basis using SELECT <dbid> where
     # dbid is a number between 0 and 'databases'-1
     databases 16
 
     # By default Redis shows an ASCII art logo only when started to log to the
-    # standard output and if the standard output is a TTY. Basically this means
-    # that normally a logo is displayed only in interactive sessions.
+    # standard output and if the standard output is a TTY and syslog logging is
+    # disabled. Basically this means that normally a logo is displayed only in
+    # interactive sessions.
     #
     # However it is possible to force the pre-4.0 behavior and always show a
     # ASCII art logo in startup logs by setting the following option to yes.
-    always-show-logo yes
+    always-show-logo no
+
+    # By default, Redis modifies the process title (as seen in 'top' and 'ps') to
+    # provide some runtime information. It is possible to disable this and leave
+    # the process name as executed by setting the following to no.
+    set-proc-title yes
+
+    # When changing the process title, Redis uses the following template to construct
+    # the modified title.
+    #
+    # Template variables are specified in curly brackets. The following variables are
+    # supported:
+    #
+    # {title}           Name of process as executed if parent, or type of child process.
+    # {listen-addr}     Bind address or '*' followed by TCP or TLS port listening on, or
+    #                   Unix socket if only that's available.
+    # {server-mode}     Special mode, i.e. "[sentinel]" or "[cluster]".
+    # {port}            TCP port listening on, or 0.
+    # {tls-port}        TLS port listening on, or 0.
+    # {unixsocket}      Unix domain socket listening on, or "".
+    # {config-file}     Name of configuration file used.
+    #
+    proc-title-template "{title} {listen-addr} {server-mode}"
 
     ################################ SNAPSHOTTING  ################################
-    #
-    # Save the DB on disk:
-    #
-    #   save <seconds> <changes>
-    #
-    #   Will save the DB if both the given number of seconds and the given
-    #   number of write operations against the DB occurred.
-    #
-    #   In the example below the behaviour will be to save:
-    #   after 900 sec (15 min) if at least 1 key changed
-    #   after 300 sec (5 min) if at least 10 keys changed
-    #   after 60 sec if at least 10000 keys changed
-    #
-    #   Note: you can disable saving completely by commenting out all "save" lines.
-    #
-    #   It is also possible to remove all the previously configured save
-    #   points by adding a save directive with a single empty string argument
-    #   like in the following example:
-    #
-    #   save ""
 
-    save 900 1
-    save 300 10
-    save 60 10000
+    # Save the DB to disk.
+    #
+    # save <seconds> <changes> [<seconds> <changes> ...]
+    #
+    # Redis will save the DB if the given number of seconds elapsed and it
+    # surpassed the given number of write operations against the DB.
+    #
+    # Snapshotting can be completely disabled with a single empty string argument
+    # as in following example:
+    #
+    # save ""
+    #
+    # Unless specified otherwise, by default Redis will save the DB:
+    #   * After 3600 seconds (an hour) if at least 1 change was performed
+    #   * After 300 seconds (5 minutes) if at least 100 changes were performed
+    #   * After 60 seconds if at least 10000 changes were performed
+    #
+    # You can set these explicitly by uncommenting the following line.
+    #
+    # save 3600 1 300 100 60 10000
+
+    save 900 1 300 10 60 10000
 
     # By default Redis will stop accepting writes if RDB snapshots are enabled
     # (at least one save point) and the latest background save failed.
@@ -329,7 +462,7 @@ data:
     stop-writes-on-bgsave-error yes
 
     # Compress string objects using LZF when dump .rdb databases?
-    # For default that's set to 'yes' as it's almost always a win.
+    # By default compression is enabled as it's almost always a win.
     # If you want to save some CPU in the saving child set it to 'no' but
     # the dataset will likely be bigger if you have compressible values or keys.
     rdbcompression yes
@@ -343,8 +476,23 @@ data:
     # tell the loading code to skip the check.
     rdbchecksum yes
 
+    # Enables or disables full sanitization checks for ziplist and listpack etc when
+    # loading an RDB or RESTORE payload. This reduces the chances of a assertion or
+    # crash later on while processing commands.
+    # Options:
+    #   no         - Never perform full sanitization
+    #   yes        - Always perform full sanitization
+    #   clients    - Perform full sanitization only for user connections.
+    #                Excludes: RDB files, RESTORE commands received from the master
+    #                connection, and client connections which have the
+    #                skip-sanitize-payload ACL flag.
+    # The default should be 'clients' but since it currently affects cluster
+    # resharding via MIGRATE, it is temporarily set to 'no' by default.
+    #
+    # sanitize-dump-payload no
+
     # The filename where to dump the DB
-    dbfilename "dump.rdb"
+    dbfilename dump.rdb
 
     # Remove RDB files used by replication in instances without persistence
     # enabled. By default this option is disabled, however there are environments
@@ -367,7 +515,7 @@ data:
     # The Append Only File will also be created inside this directory.
     #
     # Note that you must specify a directory here, not a file name.
-    dir "/data"
+    dir /data
 
     ################################# REPLICATION #################################
 
@@ -397,7 +545,7 @@ data:
     # starting the replication synchronization process, otherwise the master will
     # refuse the replica request.
     #
-    
+    # masterauth <master-password>
     #
     # However this is not enough if you are using Redis ACLs (for Redis version
     # 6 or greater), and the default user is not capable of running the PSYNC
@@ -405,7 +553,7 @@ data:
     # better to configure a special user to use with replication, and specify the
     # masteruser configuration as such:
     #
-    #masteruser master
+    # masteruser <username>
     #
     # When masteruser is specified, the replica will authenticate against its
     # master using the new AUTH form: AUTH <username> <password>.
@@ -417,11 +565,12 @@ data:
     #    still reply to client requests, possibly with out of date data, or the
     #    data set may just be empty if this is the first synchronization.
     #
-    # 2) if replica-serve-stale-data is set to 'no' the replica will reply with
-    #    an error "SYNC with master in progress" to all the kind of commands
-    #    but to INFO, replicaOF, AUTH, PING, SHUTDOWN, REPLCONF, ROLE, CONFIG,
-    #    SUBSCRIBE, UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, PUBLISH, PUBSUB,
-    #    COMMAND, POST, HOST: and LATENCY.
+    # 2) If replica-serve-stale-data is set to 'no' the replica will reply with error
+    #    "MASTERDOWN Link with MASTER is down and replica-serve-stale-data is set to 'no'"
+    #    to all data access commands, excluding commands such as:
+    #    INFO, REPLICAOF, AUTH, SHUTDOWN, REPLCONF, ROLE, CONFIG, SUBSCRIBE,
+    #    UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, PUBLISH, PUBSUB, COMMAND, POST,
+    #    HOST and LATENCY.
     #
     replica-serve-stale-data yes
 
@@ -468,7 +617,7 @@ data:
     #
     # With slow disks and fast (large bandwidth) networks, diskless replication
     # works better.
-    repl-diskless-sync no
+    repl-diskless-sync yes
 
     # When diskless replication is enabled, it is possible to configure the delay
     # the server waits in order to spawn the child that transfers the RDB via socket
@@ -482,33 +631,43 @@ data:
     # it entirely just set it to 0 seconds and the transfer will start ASAP.
     repl-diskless-sync-delay 5
 
+    # When diskless replication is enabled with a delay, it is possible to let
+    # the replication start before the maximum delay is reached if the maximum
+    # number of replicas expected have connected. Default of 0 means that the
+    # maximum is not defined and Redis will wait the full delay.
+    repl-diskless-sync-max-replicas 0
+
     # -----------------------------------------------------------------------------
     # WARNING: RDB diskless load is experimental. Since in this setup the replica
     # does not immediately store an RDB on disk, it may cause data loss during
     # failovers. RDB diskless load + Redis modules not handling I/O reads may also
     # cause Redis to abort in case of I/O errors during the initial synchronization
-    # stage with the master. Use only if your do what you are doing.
+    # stage with the master. Use only if you know what you are doing.
     # -----------------------------------------------------------------------------
     #
     # Replica can load the RDB it reads from the replication link directly from the
     # socket, or store the RDB to a file and read that file after it was completely
-    # recived from the master.
+    # received from the master.
     #
     # In many cases the disk is slower than the network, and storing and loading
     # the RDB file may increase replication time (and even increase the master's
-    # Copy on Write memory and salve buffers).
+    # Copy on Write memory and replica buffers).
     # However, parsing the RDB file directly from the socket may mean that we have
     # to flush the contents of the current database before the full rdb was
     # received. For this reason we have the following options:
     #
     # "disabled"    - Don't use diskless load (store the rdb file to the disk first)
     # "on-empty-db" - Use diskless load only when it is completely safe.
-    # "swapdb"      - Keep a copy of the current db contents in RAM while parsing
-    #                 the data directly from the socket. note that this requires
-    #                 sufficient memory, if you don't have it, you risk an OOM kill.
+    # "swapdb"      - Keep current db contents in RAM while parsing the data directly
+    #                 from the socket. Replicas in this mode can keep serving current
+    #                 data set while replication is in progress, except for cases where
+    #                 they can't recognize master as having a data set from same
+    #                 replication history.
+    #                 Note that this requires sufficient memory, if you don't have it,
+    #                 you risk an OOM kill.
     repl-diskless-load disabled
 
-    # Replicas send PINGs to server in a predefined interval. It's possible to
+    # Master send PINGs to its replicas in a predefined interval. It's possible to
     # change this interval with the repl_ping_replica_period option. The default
     # value is 10 seconds.
     #
@@ -522,7 +681,8 @@ data:
     #
     # It is important to make sure that this value is greater than the value
     # specified for repl-ping-replica-period otherwise a timeout will be detected
-    # every time there is low traffic between the master and the replica.
+    # every time there is low traffic between the master and the replica. The default
+    # value is 60 seconds.
     #
     # repl-timeout 60
 
@@ -547,21 +707,21 @@ data:
     # partial resync is enough, just passing the portion of data the replica
     # missed while disconnected.
     #
-    # The bigger the replication backlog, the longer the time the replica can be
-    # disconnected and later be able to perform a partial resynchronization.
+    # The bigger the replication backlog, the longer the replica can endure the
+    # disconnect and later be able to perform a partial resynchronization.
     #
-    # The backlog is only allocated once there is at least a replica connected.
+    # The backlog is only allocated if there is at least one replica connected.
     #
     # repl-backlog-size 1mb
 
-    # After a master has no longer connected replicas for some time, the backlog
-    # will be freed. The following option configures the amount of seconds that
-    # need to elapse, starting from the time the last replica disconnected, for
-    # the backlog buffer to be freed.
+    # After a master has no connected replicas for some time, the backlog will be
+    # freed. The following option configures the amount of seconds that need to
+    # elapse, starting from the time the last replica disconnected, for the backlog
+    # buffer to be freed.
     #
     # Note that replicas never free the backlog for timeout, since they may be
     # promoted to masters later, and should be able to correctly "partially
-    # resynchronize" with the replicas: hence they should always accumulate backlog.
+    # resynchronize" with other replicas: hence they should always accumulate backlog.
     #
     # A value of 0 means to never release the backlog.
     #
@@ -581,6 +741,43 @@ data:
     #
     # By default the priority is 100.
     replica-priority 100
+
+    # The propagation error behavior controls how Redis will behave when it is
+    # unable to handle a command being processed in the replication stream from a master
+    # or processed while reading from an AOF file. Errors that occur during propagation
+    # are unexpected, and can cause data inconsistency. However, there are edge cases
+    # in earlier versions of Redis where it was possible for the server to replicate or persist
+    # commands that would fail on future versions. For this reason the default behavior
+    # is to ignore such errors and continue processing commands.
+    #
+    # If an application wants to ensure there is no data divergence, this configuration
+    # should be set to 'panic' instead. The value can also be set to 'panic-on-replicas'
+    # to only panic when a replica encounters an error on the replication stream. One of
+    # these two panic values will become the default value in the future once there are
+    # sufficient safety mechanisms in place to prevent false positive crashes.
+    #
+    # propagation-error-behavior ignore
+
+    # Replica ignore disk write errors controls the behavior of a replica when it is
+    # unable to persist a write command received from its master to disk. By default,
+    # this configuration is set to 'no' and will crash the replica in this condition.
+    # It is not recommended to change this default, however in order to be compatible
+    # with older versions of Redis this config can be toggled to 'yes' which will just
+    # log a warning and execute the write command it got from the master.
+    #
+    # replica-ignore-disk-write-errors no
+
+    # -----------------------------------------------------------------------------
+    # By default, Redis Sentinel includes all replicas in its reports. A replica
+    # can be excluded from Redis Sentinel's announcements. An unannounced replica
+    # will be ignored by the 'sentinel replicas <master>' command and won't be
+    # exposed to Redis Sentinel's clients.
+    #
+    # This option does not change the behavior of replica-priority. Even with
+    # replica-announced set to 'no', the replica can be promoted to master. To
+    # prevent this behavior, set replica-priority to 0.
+    #
+    # replica-announced yes
 
     # It is possible for a master to stop accepting writes if there are less than
     # N replicas connected, having a lag less or equal than M seconds.
@@ -611,8 +808,8 @@ data:
     # Another place where this info is available is in the output of the
     # "ROLE" command of a master.
     #
-    # The listed IP and address normally reported by a replica is obtained
-    # in the following way:
+    # The listed IP address and port normally reported by a replica is
+    # obtained in the following way:
     #
     #   IP: The address is auto detected by checking the peer address
     #   of the socket used by the replica to connect with the master.
@@ -622,7 +819,7 @@ data:
     #   listen for connections.
     #
     # However when port forwarding or Network Address Translation (NAT) is
-    # used, the replica may be actually reachable via different IP and port
+    # used, the replica may actually be reachable via different IP and port
     # pairs. The following two options can be used by a replica in order to
     # report to its master a specific set of IP and port, so that both INFO
     # and ROLE will report those values.
@@ -637,9 +834,9 @@ data:
 
     # Redis implements server assisted support for client side caching of values.
     # This is implemented using an invalidation table that remembers, using
-    # 16 millions of slots, what clients may have certain subsets of keys. In turn
+    # a radix key indexed by key name, what clients have which keys. In turn
     # this is used in order to send invalidation messages to clients. Please
-    # to understand more about the feature check this page:
+    # check this page to understand more about the feature:
     #
     #   https://redis.io/topics/client-side-caching
     #
@@ -671,7 +868,7 @@ data:
 
     ################################## SECURITY ###################################
 
-    # Warning: since Redis is pretty fast an outside user can try up to
+    # Warning: since Redis is pretty fast, an outside user can try up to
     # 1 million passwords per second against a modern box. This means that you
     # should use very strong passwords, otherwise they will be very easy to break.
     # Note that because the password is really a shared secret between the client
@@ -695,14 +892,18 @@ data:
     # AUTH (or the HELLO command AUTH option) in order to be authenticated and
     # start to work.
     #
-    # The ACL rules that describe what an user can do are the following:
+    # The ACL rules that describe what a user can do are the following:
     #
     #  on           Enable the user: it is possible to authenticate as this user.
     #  off          Disable the user: it's no longer possible to authenticate
     #               with this user, however the already authenticated connections
     #               will still work.
-    #  +<command>   Allow the execution of that command
-    #  -<command>   Disallow the execution of that command
+    #  skip-sanitize-payload    RESTORE dump-payload sanitization is skipped.
+    #  sanitize-payload         RESTORE dump-payload is sanitized (default).
+    #  +<command>   Allow the execution of that command.
+    #               May be used with `|` for allowing subcommands (e.g "+config|get")
+    #  -<command>   Disallow the execution of that command.
+    #               May be used with `|` for blocking subcommands (e.g "-config|set")
     #  +@<category> Allow the execution of all the commands in such category
     #               with valid categories are like @admin, @set, @sortedset, ...
     #               and so forth, see the full list in the server.c file where
@@ -710,10 +911,11 @@ data:
     #               The special category @all means all the commands, but currently
     #               present in the server, and that will be loaded in the future
     #               via modules.
-    #  +<command>|subcommand    Allow a specific subcommand of an otherwise
-    #                           disabled command. Note that this form is not
-    #                           allowed as negative like -DEBUG|SEGFAULT, but
-    #                           only additive starting with "+".
+    #  +<command>|first-arg  Allow a specific first argument of an otherwise
+    #                        disabled command. It is only supported on commands with
+    #                        no sub-commands, and is not allowed as negative form
+    #                        like -SELECT|1, only additive starting with "+". This
+    #                        feature is deprecated and may be removed in the future.
     #  allcommands  Alias for +@all. Note that it implies the ability to execute
     #               all the future commands loaded via the modules system.
     #  nocommands   Alias for -@all.
@@ -721,9 +923,18 @@ data:
     #               commands. For instance ~* allows all the keys. The pattern
     #               is a glob-style pattern like the one of KEYS.
     #               It is possible to specify multiple patterns.
+    # %R~<pattern>  Add key read pattern that specifies which keys can be read 
+    #               from.
+    # %W~<pattern>  Add key write pattern that specifies which keys can be
+    #               written to. 
     #  allkeys      Alias for ~*
     #  resetkeys    Flush the list of allowed keys patterns.
-    #  ><password>  Add this passowrd to the list of valid password for the user.
+    #  &<pattern>   Add a glob-style pattern of Pub/Sub channels that can be
+    #               accessed by the user. It is possible to specify multiple channel
+    #               patterns.
+    #  allchannels  Alias for &*
+    #  resetchannels            Flush the list of allowed channel patterns.
+    #  ><password>  Add this password to the list of valid password for the user.
     #               For example >mypass will add "mypass" to the list.
     #               This directive clears the "nopass" flag (see later).
     #  <<password>  Remove this password from the list of valid passwords.
@@ -741,6 +952,14 @@ data:
     #  reset        Performs the following actions: resetpass, resetkeys, off,
     #               -@all. The user returns to the same state it has immediately
     #               after its creation.
+    # (<options>)   Create a new selector with the options specified within the
+    #               parentheses and attach it to the user. Each option should be 
+    #               space separated. The first character must be ( and the last 
+    #               character must be ).
+    # clearselectors            Remove all of the currently attached selectors. 
+    #                           Note this does not change the "root" user permissions,
+    #                           which are the permissions directly applied onto the
+    #                           user (outside the parentheses).
     #
     # ACL rules can be specified in any order: for instance you can start with
     # passwords, then flags, or key patterns. However note that the additive
@@ -762,6 +981,40 @@ data:
     #
     # Basically ACL rules are processed left-to-right.
     #
+    # The following is a list of command categories and their meanings:
+    # * keyspace - Writing or reading from keys, databases, or their metadata 
+    #     in a type agnostic way. Includes DEL, RESTORE, DUMP, RENAME, EXISTS, DBSIZE,
+    #     KEYS, EXPIRE, TTL, FLUSHALL, etc. Commands that may modify the keyspace,
+    #     key or metadata will also have `write` category. Commands that only read
+    #     the keyspace, key or metadata will have the `read` category.
+    # * read - Reading from keys (values or metadata). Note that commands that don't
+    #     interact with keys, will not have either `read` or `write`.
+    # * write - Writing to keys (values or metadata)
+    # * admin - Administrative commands. Normal applications will never need to use
+    #     these. Includes REPLICAOF, CONFIG, DEBUG, SAVE, MONITOR, ACL, SHUTDOWN, etc.
+    # * dangerous - Potentially dangerous (each should be considered with care for
+    #     various reasons). This includes FLUSHALL, MIGRATE, RESTORE, SORT, KEYS,
+    #     CLIENT, DEBUG, INFO, CONFIG, SAVE, REPLICAOF, etc.
+    # * connection - Commands affecting the connection or other connections.
+    #     This includes AUTH, SELECT, COMMAND, CLIENT, ECHO, PING, etc.
+    # * blocking - Potentially blocking the connection until released by another
+    #     command.
+    # * fast - Fast O(1) commands. May loop on the number of arguments, but not the
+    #     number of elements in the key.
+    # * slow - All commands that are not Fast.
+    # * pubsub - PUBLISH / SUBSCRIBE related
+    # * transaction - WATCH / MULTI / EXEC related commands.
+    # * scripting - Scripting related.
+    # * set - Data type: sets related.
+    # * sortedset - Data type: zsets related.
+    # * list - Data type: lists related.
+    # * hash - Data type: hashes related.
+    # * string - Data type: strings related.
+    # * bitmap - Data type: bitmaps related.
+    # * hyperloglog - Data type: hyperloglog related.
+    # * geo - Data type: geo related.
+    # * stream - Data type: streams related.
+    #
     # For more information about ACL configuration please refer to
     # the Redis web site at https://redis.io/topics/acl
 
@@ -777,7 +1030,7 @@ data:
     #
     # Instead of configuring users here in this file, it is possible to use
     # a stand-alone file just listing users. The two methods cannot be mixed:
-    # if you configure users here and at the same time you activate the exteranl
+    # if you configure users here and at the same time you activate the external
     # ACL file, the server will refuse to start.
     #
     # The format of the external ACL user file is exactly the same as the
@@ -785,13 +1038,29 @@ data:
     #
     # aclfile /etc/redis/users.acl
 
-    # IMPORTANT NOTE: starting with Redis 6 "requirepass" is just a compatiblity
+    # IMPORTANT NOTE: starting with Redis 6 "requirepass" is just a compatibility
     # layer on top of the new ACL system. The option effect will be just setting
     # the password for the default user. Clients will still authenticate using
     # AUTH <password> as usually, or more explicitly with AUTH default <password>
     # if they follow the new protocol: both will work.
     #
-    
+    # The requirepass is not compatible with aclfile option and the ACL LOAD
+    # command, these will cause requirepass to be ignored.
+    #
+    # requirepass foobared
+
+    # New users are initialized with restrictive permissions by default, via the
+    # equivalent of this ACL rule 'off resetkeys -@all'. Starting with Redis 6.2, it
+    # is possible to manage access to Pub/Sub channels with ACL rules as well. The
+    # default Pub/Sub channels permission if new users is controlled by the
+    # acl-pubsub-default configuration directive, which accepts one of these values:
+    #
+    # allchannels: grants access to all Pub/Sub channels
+    # resetchannels: revokes access to all Pub/Sub channels
+    #
+    # From Redis 7.0, acl-pubsub-default defaults to 'resetchannels' permission.
+    #
+    # acl-pubsub-default resetchannels
 
     # Command renaming (DEPRECATED).
     #
@@ -881,14 +1150,12 @@ data:
     # Both LRU, LFU and volatile-ttl are implemented using approximated
     # randomized algorithms.
     #
-    # Note: with any of the above policies, Redis will return an error on write
-    #       operations, when there are no suitable keys for eviction.
-    #
-    #       At the date of writing these commands are: set setnx setex append
-    #       incr decr rpush lpush rpushx lpushx linsert lset rpoplpush sadd
-    #       sinter sinterstore sunion sunionstore sdiff sdiffstore zadd zincrby
-    #       zunionstore zinterstore hset hsetnx hmset hincrby incrby decrby
-    #       getset mset msetnx exec sort
+    # Note: with any of the above policies, when there are no suitable keys for
+    # eviction, Redis will return an error on write operations that require
+    # more memory. These are usually commands that create new keys, add data or
+    # modify existing keys. A few examples are: SET, INCR, HSET, LPUSH, SUNIONSTORE,
+    # SORT (due to the STORE argument), and EXEC (if the transaction includes any
+    # command that requires memory).
     #
     # The default is:
     #
@@ -896,14 +1163,22 @@ data:
 
     # LRU, LFU and minimal TTL algorithms are not precise algorithms but approximated
     # algorithms (in order to save memory), so you can tune it for speed or
-    # accuracy. For default Redis will check five keys and pick the one that was
-    # used less recently, you can change the sample size using the following
+    # accuracy. By default Redis will check five keys and pick the one that was
+    # used least recently, you can change the sample size using the following
     # configuration directive.
     #
     # The default of 5 produces good enough results. 10 Approximates very closely
     # true LRU but costs more CPU. 3 is faster but not very accurate.
     #
     # maxmemory-samples 5
+
+    # Eviction processing is designed to function well with the default setting.
+    # If there is an unusually large amount of write traffic, this value may need to
+    # be increased.  Decreasing this value may reduce latency at the risk of
+    # eviction processing effectiveness
+    #   0 = minimum latency, 10 = default, 100 = process without regard to latency
+    #
+    # maxmemory-eviction-tenacity 10
 
     # Starting from Redis 5, by default a replica will ignore its maxmemory setting
     # (unless it is promoted to master after a failover or manually). It means
@@ -937,8 +1212,8 @@ data:
     # it is possible to increase the expire "effort" that is normally set to
     # "1", to a greater value, up to the value "10". At its maximum value the
     # system will use more CPU, longer cycles (and technically may introduce
-    # more latency), and will tollerate less already expired keys still present
-    # in the system. It's a tradeoff betweeen memory, CPU and latecy.
+    # more latency), and will tolerate less already expired keys still present
+    # in the system. It's a tradeoff between memory, CPU and latency.
     #
     # active-expire-effort 1
 
@@ -998,6 +1273,13 @@ data:
 
     lazyfree-lazy-user-del no
 
+    # FLUSHDB, FLUSHALL, SCRIPT FLUSH and FUNCTION FLUSH support both asynchronous and synchronous
+    # deletion, which can be controlled by passing the [SYNC|ASYNC] flags into the
+    # commands. When neither flag is passed, this directive will be used to determine
+    # if the data should be deleted asynchronously.
+
+    lazyfree-lazy-user-flush no
+
     ################################ THREADED I/O #################################
 
     # Redis is mostly single threaded, however there are certain threaded
@@ -1006,7 +1288,7 @@ data:
     #
     # Now it is also possible to handle Redis clients socket reads and writes
     # in different I/O threads. Since especially writing is so slow, normally
-    # Redis users use pipelining in order to speedup the Redis performances per
+    # Redis users use pipelining in order to speed up the Redis performances per
     # core, and spawn multiple instances in order to scale more. Using I/O
     # threads it is possible to easily speedup two times Redis without resorting
     # to pipelining nor sharding of the instance.
@@ -1024,7 +1306,7 @@ data:
     #
     # io-threads 4
     #
-    # Setting io-threads to 1 will just use the main thread as usually.
+    # Setting io-threads to 1 will just use the main thread as usual.
     # When I/O threads are enabled, we only use threads for writes, that is
     # to thread the write(2) syscall and transfer the client buffers to the
     # socket. However it is also possible to enable threading of reads and
@@ -1036,13 +1318,57 @@ data:
     # Usually threading reads doesn't help much.
     #
     # NOTE 1: This configuration directive cannot be changed at runtime via
-    # CONFIG SET. Aso this feature currently does not work when SSL is
+    # CONFIG SET. Also, this feature currently does not work when SSL is
     # enabled.
     #
     # NOTE 2: If you want to test the Redis speedup using redis-benchmark, make
     # sure you also run the benchmark itself in threaded mode, using the
-    # --threads option to match the number of Redis theads, otherwise you'll not
+    # --threads option to match the number of Redis threads, otherwise you'll not
     # be able to notice the improvements.
+
+    ############################ KERNEL OOM CONTROL ##############################
+
+    # On Linux, it is possible to hint the kernel OOM killer on what processes
+    # should be killed first when out of memory.
+    #
+    # Enabling this feature makes Redis actively control the oom_score_adj value
+    # for all its processes, depending on their role. The default scores will
+    # attempt to have background child processes killed before all others, and
+    # replicas killed before masters.
+    #
+    # Redis supports these options:
+    #
+    # no:       Don't make changes to oom-score-adj (default).
+    # yes:      Alias to "relative" see below.
+    # absolute: Values in oom-score-adj-values are written as is to the kernel.
+    # relative: Values are used relative to the initial value of oom_score_adj when
+    #           the server starts and are then clamped to a range of -1000 to 1000.
+    #           Because typically the initial value is 0, they will often match the
+    #           absolute values.
+    oom-score-adj no
+
+    # When oom-score-adj is used, this directive controls the specific values used
+    # for master, replica and background child processes. Values range -2000 to
+    # 2000 (higher means more likely to be killed).
+    #
+    # Unprivileged processes (not root, and without CAP_SYS_RESOURCE capabilities)
+    # can freely increase their value, but not decrease it below its initial
+    # settings. This means that setting oom-score-adj to "relative" and setting the
+    # oom-score-adj-values to positive values will always succeed.
+    oom-score-adj-values 0 200 800
+
+
+    #################### KERNEL transparent hugepage CONTROL ######################
+
+    # Usually the kernel Transparent Huge Pages control is set to "madvise" or
+    # or "never" by default (/sys/kernel/mm/transparent_hugepage/enabled), in which
+    # case this config has no effect. On systems in which it is set to "always",
+    # redis will attempt to disable it specifically for the redis process in order
+    # to avoid latency problems specifically with fork(2) and CoW.
+    # If for some reason you prefer to keep it enabled, you can set this config to
+    # "no" and the kernel global to "always".
+
+    disable-thp yes
 
     ############################## APPEND ONLY MODE ###############################
 
@@ -1062,13 +1388,42 @@ data:
     # If the AOF is enabled on startup Redis will load the AOF, that is the file
     # with the better durability guarantees.
     #
-    # Please check http://redis.io/topics/persistence for more information.
+    # Please check https://redis.io/topics/persistence for more information.
 
     appendonly yes
 
-    # The name of the append only file (default: "appendonly.aof")
+    # The base name of the append only file.
+    #
+    # Redis 7 and newer use a set of append-only files to persist the dataset
+    # and changes applied to it. There are two basic types of files in use:
+    #
+    # - Base files, which are a snapshot representing the complete state of the
+    #   dataset at the time the file was created. Base files can be either in
+    #   the form of RDB (binary serialized) or AOF (textual commands).
+    # - Incremental files, which contain additional commands that were applied
+    #   to the dataset following the previous file.
+    #
+    # In addition, manifest files are used to track the files and the order in
+    # which they were created and should be applied.
+    #
+    # Append-only file names are created by Redis following a specific pattern.
+    # The file name's prefix is based on the 'appendfilename' configuration
+    # parameter, followed by additional information about the sequence and type.
+    #
+    # For example, if appendfilename is set to appendonly.aof, the following file
+    # names could be derived:
+    #
+    # - appendonly.aof.1.base.rdb as a base file.
+    # - appendonly.aof.1.incr.aof, appendonly.aof.2.incr.aof as incremental files.
+    # - appendonly.aof.manifest as a manifest file.
 
     appendfilename "appendonly.aof"
+
+    # For convenience, Redis stores all persistent append-only files in a dedicated
+    # directory. The name of the directory is determined by the appenddirname
+    # configuration parameter.
+
+    appenddirname "appendonlydir"
 
     # The fsync() call tells the Operating System to actually write data on disk
     # instead of waiting for more data in the output buffer. Some OS will really flush
@@ -1109,7 +1464,7 @@ data:
     # BGSAVE or BGREWRITEAOF is in progress.
     #
     # This means that while another child is saving, the durability of Redis is
-    # the same as "appendfsync none". In practical terms, this means that it is
+    # the same as "appendfsync no". In practical terms, this means that it is
     # possible to lose up to 30 seconds of log in the worst scenario (with the
     # default Linux settings).
     #
@@ -1162,34 +1517,69 @@ data:
     # will be found.
     aof-load-truncated yes
 
-    # When rewriting the AOF file, Redis is able to use an RDB preamble in the
-    # AOF file for faster rewrites and recoveries. When this option is turned
-    # on the rewritten AOF file is composed of two different stanzas:
-    #
-    #   [RDB file][AOF tail]
-    #
-    # When loading Redis recognizes that the AOF file starts with the "REDIS"
-    # string and loads the prefixed RDB file, and continues loading the AOF
-    # tail.
+    # Redis can create append-only base files in either RDB or AOF formats. Using
+    # the RDB format is always faster and more efficient, and disabling it is only
+    # supported for backward compatibility purposes.
     aof-use-rdb-preamble yes
 
-    ################################ LUA SCRIPTING  ###############################
+    # Redis supports recording timestamp annotations in the AOF to support restoring
+    # the data from a specific point-in-time. However, using this capability changes
+    # the AOF format in a way that may not be compatible with existing AOF parsers.
+    aof-timestamp-enabled no
 
-    # Max execution time of a Lua script in milliseconds.
+    ################################ SHUTDOWN #####################################
+
+    # Maximum time to wait for replicas when shutting down, in seconds.
     #
-    # If the maximum execution time is reached Redis will log that a script is
-    # still in execution after the maximum allowed time and will start to
-    # reply to queries with an error.
+    # During shut down, a grace period allows any lagging replicas to catch up with
+    # the latest replication offset before the master exists. This period can
+    # prevent data loss, especially for deployments without configured disk backups.
     #
-    # When a long running script exceeds the maximum execution time only the
-    # SCRIPT KILL and SHUTDOWN NOSAVE commands are available. The first can be
-    # used to stop a script that did not yet called write commands. The second
-    # is the only way to shut down the server in the case a write command was
-    # already issued by the script but the user doesn't want to wait for the natural
-    # termination of the script.
+    # The 'shutdown-timeout' value is the grace period's duration in seconds. It is
+    # only applicable when the instance has replicas. To disable the feature, set
+    # the value to 0.
     #
-    # Set it to 0 or a negative value for unlimited execution without warnings.
-    lua-time-limit 5000
+    # shutdown-timeout 10
+
+    # When Redis receives a SIGINT or SIGTERM, shutdown is initiated and by default
+    # an RDB snapshot is written to disk in a blocking operation if save points are configured.
+    # The options used on signaled shutdown can include the following values:
+    # default:  Saves RDB snapshot only if save points are configured.
+    #           Waits for lagging replicas to catch up.
+    # save:     Forces a DB saving operation even if no save points are configured.
+    # nosave:   Prevents DB saving operation even if one or more save points are configured.
+    # now:      Skips waiting for lagging replicas.
+    # force:    Ignores any errors that would normally prevent the server from exiting.
+    #
+    # Any combination of values is allowed as long as "save" and "nosave" are not set simultaneously.
+    # Example: "nosave force now"
+    #
+    # shutdown-on-sigint default
+    # shutdown-on-sigterm default
+
+    ################ NON-DETERMINISTIC LONG BLOCKING COMMANDS #####################
+
+    # Maximum time in milliseconds for EVAL scripts, functions and in some cases
+    # modules' commands before Redis can start processing or rejecting other clients.
+    #
+    # If the maximum execution time is reached Redis will start to reply to most
+    # commands with a BUSY error.
+    #
+    # In this state Redis will only allow a handful of commands to be executed.
+    # For instance, SCRIPT KILL, FUNCTION KILL, SHUTDOWN NOSAVE and possibly some
+    # module specific 'allow-busy' commands.
+    #
+    # SCRIPT KILL and FUNCTION KILL will only be able to stop a script that did not
+    # yet call any write commands, so SHUTDOWN NOSAVE may be the only way to stop
+    # the server in the case a write command was already issued by the script when
+    # the user doesn't want to wait for the natural termination of the script.
+    #
+    # The default is 5 seconds. It is possible to set it to 0 or a negative value
+    # to disable this mechanism (uninterrupted execution). Note that in the past
+    # this config had a different name, which is now an alias, so both of these do
+    # the same:
+    # lua-time-limit 5000
+    # busy-reply-threshold 5000
 
     ################################ REDIS CLUSTER  ###############################
 
@@ -1209,9 +1599,14 @@ data:
 
     # Cluster node timeout is the amount of milliseconds a node must be unreachable
     # for it to be considered in failure state.
-    # Most other internal time limits are multiple of the node timeout.
+    # Most other internal time limits are a multiple of the node timeout.
     #
     # cluster-node-timeout 15000
+
+    # The cluster port is the port that the cluster bus will listen for inbound connections on. When set 
+    # to the default value, 0, it will be bound to the command port + 10000. Setting this value requires 
+    # you to specify the cluster bus port when executing cluster meet.
+    # cluster-port 0
 
     # A replica of a failing master will avoid to start a failover if its data
     # looks too old.
@@ -1236,18 +1631,18 @@ data:
     # the failover if, since the last interaction with the master, the time
     # elapsed is greater than:
     #
-    #   (node-timeout * replica-validity-factor) + repl-ping-replica-period
+    #   (node-timeout * cluster-replica-validity-factor) + repl-ping-replica-period
     #
-    # So for example if node-timeout is 30 seconds, and the replica-validity-factor
+    # So for example if node-timeout is 30 seconds, and the cluster-replica-validity-factor
     # is 10, and assuming a default repl-ping-replica-period of 10 seconds, the
     # replica will not try to failover if it was not able to talk with the master
     # for longer than 310 seconds.
     #
-    # A large replica-validity-factor may allow replicas with too old data to failover
+    # A large cluster-replica-validity-factor may allow replicas with too old data to failover
     # a master, while a too small value may prevent the cluster from being able to
     # elect a replica at all.
     #
-    # For maximum availability, it is possible to set the replica-validity-factor
+    # For maximum availability, it is possible to set the cluster-replica-validity-factor
     # to a value of 0, which means, that replicas will always try to failover the
     # master regardless of the last time they interacted with the master.
     # (However they'll always try to apply a delay proportional to their
@@ -1271,14 +1666,23 @@ data:
     # master in your cluster.
     #
     # Default is 1 (replicas migrate only if their masters remain with at least
-    # one replica). To disable migration just set it to a very large value.
+    # one replica). To disable migration just set it to a very large value or
+    # set cluster-allow-replica-migration to 'no'.
     # A value of 0 can be set but is useful only for debugging and dangerous
     # in production.
     #
     # cluster-migration-barrier 1
 
+    # Turning off this option allows to use less automatic cluster configuration.
+    # It both disables migration to orphaned masters and migration from masters
+    # that became empty.
+    #
+    # Default is 'yes' (allow automatic migrations).
+    #
+    # cluster-allow-replica-migration yes
+
     # By default Redis Cluster nodes stop accepting queries if they detect there
-    # is at least an hash slot uncovered (no available node is serving it).
+    # is at least a hash slot uncovered (no available node is serving it).
     # This way if the cluster is partially down (for example a range of hash slots
     # are no longer covered) all the cluster becomes, eventually, unavailable.
     # It automatically returns available as soon as all the slots are covered again.
@@ -1291,7 +1695,7 @@ data:
     # cluster-require-full-coverage yes
 
     # This option, when set to yes, prevents replicas from trying to failover its
-    # master during master failures. However the master can still perform a
+    # master during master failures. However the replica can still perform a
     # manual failover, if forced to do so.
     #
     # This is useful in different scenarios, especially in the case of multiple
@@ -1301,7 +1705,7 @@ data:
     # cluster-replica-no-failover no
 
     # This option, when set to yes, allows nodes to serve read traffic while the
-    # the cluster is in a down state, as long as it believes it owns the slots.
+    # cluster is in a down state, as long as it believes it owns the slots.
     #
     # This is useful for two cases.  The first case is for when an application
     # doesn't require consistency of data during node failures or network partitions.
@@ -1316,8 +1720,54 @@ data:
     #
     # cluster-allow-reads-when-down no
 
+    # This option, when set to yes, allows nodes to serve pubsub shard traffic while
+    # the cluster is in a down state, as long as it believes it owns the slots.
+    #
+    # This is useful if the application would like to use the pubsub feature even when
+    # the cluster global stable state is not OK. If the application wants to make sure only
+    # one shard is serving a given channel, this feature should be kept as yes.
+    #
+    # cluster-allow-pubsubshard-when-down yes
+
+    # Cluster link send buffer limit is the limit on the memory usage of an individual
+    # cluster bus link's send buffer in bytes. Cluster links would be freed if they exceed
+    # this limit. This is to primarily prevent send buffers from growing unbounded on links
+    # toward slow peers (E.g. PubSub messages being piled up).
+    # This limit is disabled by default. Enable this limit when 'mem_cluster_links' INFO field
+    # and/or 'send-buffer-allocated' entries in the 'CLUSTER LINKS` command output continuously increase.
+    # Minimum limit of 1gb is recommended so that cluster link buffer can fit in at least a single
+    # PubSub message by default. (client-query-buffer-limit default value is 1gb)
+    #
+    # cluster-link-sendbuf-limit 0
+    
+    # Clusters can configure their announced hostname using this config. This is a common use case for 
+    # applications that need to use TLS Server Name Indication (SNI) or dealing with DNS based
+    # routing. By default this value is only shown as additional metadata in the CLUSTER SLOTS
+    # command, but can be changed using 'cluster-preferred-endpoint-type' config. This value is 
+    # communicated along the clusterbus to all nodes, setting it to an empty string will remove 
+    # the hostname and also propagate the removal.
+    #
+    # cluster-announce-hostname ""
+
+    # Clusters can advertise how clients should connect to them using either their IP address,
+    # a user defined hostname, or by declaring they have no endpoint. Which endpoint is
+    # shown as the preferred endpoint is set by using the cluster-preferred-endpoint-type
+    # config with values 'ip', 'hostname', or 'unknown-endpoint'. This value controls how
+    # the endpoint returned for MOVED/ASKING requests as well as the first field of CLUSTER SLOTS. 
+    # If the preferred endpoint type is set to hostname, but no announced hostname is set, a '?' 
+    # will be returned instead.
+    #
+    # When a cluster advertises itself as having an unknown endpoint, it's indicating that
+    # the server doesn't know how clients can reach the cluster. This can happen in certain 
+    # networking situations where there are multiple possible routes to the node, and the 
+    # server doesn't know which one the client took. In this case, the server is expecting
+    # the client to reach out on the same endpoint it used for making the last request, but use
+    # the port provided in the response.
+    #
+    # cluster-preferred-endpoint-type ip
+
     # In order to setup your cluster make sure to read the documentation
-    # available at http://redis.io web site.
+    # available at https://redis.io web site.
 
     ########################## CLUSTER DOCKER/NAT support  ########################
 
@@ -1327,16 +1777,21 @@ data:
     #
     # In order to make Redis Cluster working in such environments, a static
     # configuration where each node knows its public address is needed. The
-    # following two options are used for this scope, and are:
+    # following four options are used for this scope, and are:
     #
     # * cluster-announce-ip
     # * cluster-announce-port
+    # * cluster-announce-tls-port
     # * cluster-announce-bus-port
     #
-    # Each instruct the node about its address, client port, and cluster message
-    # bus port. The information is then published in the header of the bus packets
-    # so that other nodes will be able to correctly map the address of the node
-    # publishing the information.
+    # Each instructs the node about its address, client ports (for connections
+    # without and with TLS) and cluster message bus port. The information is then
+    # published in the header of the bus packets so that other nodes will be able to
+    # correctly map the address of the node publishing the information.
+    #
+    # If cluster-tls is set to yes and cluster-announce-tls-port is omitted or set
+    # to zero, then cluster-announce-port refers to the TLS port. Note also that
+    # cluster-announce-tls-port has no effect if cluster-tls is set to no.
     #
     # If the above options are not used, the normal Redis Cluster auto-detection
     # will be used instead.
@@ -1344,12 +1799,13 @@ data:
     # Note that when remapped, the bus port may not be at the fixed offset of
     # clients port + 10000, so you can specify any port and bus-port depending
     # on how they get remapped. If the bus-port is not set, a fixed offset of
-    # 10000 will be used as usually.
+    # 10000 will be used as usual.
     #
     # Example:
     #
     # cluster-announce-ip 10.1.1.5
-    # cluster-announce-port 6379
+    # cluster-announce-tls-port 6379
+    # cluster-announce-port 0
     # cluster-announce-bus-port 6380
 
     ################################## SLOW LOG ###################################
@@ -1397,10 +1853,24 @@ data:
     # "CONFIG SET latency-monitor-threshold <milliseconds>" if needed.
     latency-monitor-threshold 0
 
+    ################################ LATENCY TRACKING ##############################
+
+    # The Redis extended latency monitoring tracks the per command latencies and enables
+    # exporting the percentile distribution via the INFO latencystats command,
+    # and cumulative latency distributions (histograms) via the LATENCY command.
+    #
+    # By default, the extended latency monitoring is enabled since the overhead
+    # of keeping track of the command latency is very small.
+    # latency-tracking yes
+
+    # By default the exported latency percentiles via the INFO latencystats command
+    # are the p50, p99, and p999.
+    # latency-tracking-info-percentiles 50 99 99.9
+
     ############################# EVENT NOTIFICATION ##############################
 
     # Redis can notify Pub/Sub clients about events happening in the key space.
-    # This feature is documented at http://redis.io/topics/notifications
+    # This feature is documented at https://redis.io/topics/notifications
     #
     # For instance if keyspace events notification is enabled, and a client
     # performs a DEL operation on key "foo" stored in the Database 0, two
@@ -1422,9 +1892,11 @@ data:
     #  z     Sorted set commands
     #  x     Expired events (events generated every time a key expires)
     #  e     Evicted events (events generated when a key is evicted for maxmemory)
+    #  n     New key events (Note: not included in the 'A' class)
     #  t     Stream commands
+    #  d     Module key type events
     #  m     Key-miss events (Note: It is not included in the 'A' class)
-    #  A     Alias for g$lshzxet, so that the "AKE" string means all the events
+    #  A     Alias for g$lshzxetd, so that the "AKE" string means all the events
     #        (Except key-miss events which are excluded from 'A' due to their
     #         unique nature).
     #
@@ -1447,68 +1919,13 @@ data:
     #  specify at least one of K or E, no events will be delivered.
     notify-keyspace-events ""
 
-    ############################### GOPHER SERVER #################################
-
-    # Redis contains an implementation of the Gopher protocol, as specified in
-    # the RFC 1436 (https://www.ietf.org/rfc/rfc1436.txt).
-    #
-    # The Gopher protocol was very popular in the late '90s. It is an alternative
-    # to the web, and the implementation both server and client side is so simple
-    # that the Redis server has just 100 lines of code in order to implement this
-    # support.
-    #
-    # What do you do with Gopher nowadays? Well Gopher never *really* died, and
-    # lately there is a movement in order for the Gopher more hierarchical content
-    # composed of just plain text documents to be resurrected. Some want a simpler
-    # internet, others believe that the mainstream internet became too much
-    # controlled, and it's cool to create an alternative space for people that
-    # want a bit of fresh air.
-    #
-    # Anyway for the 10nth birthday of the Redis, we gave it the Gopher protocol
-    # as a gift.
-    #
-    # --- HOW IT WORKS? ---
-    #
-    # The Redis Gopher support uses the inline protocol of Redis, and specifically
-    # two kind of inline requests that were anyway illegal: an empty request
-    # or any request that starts with "/" (there are no Redis commands starting
-    # with such a slash). Normal RESP2/RESP3 requests are completely out of the
-    # path of the Gopher protocol implementation and are served as usually as well.
-    #
-    # If you open a connection to Redis when Gopher is enabled and send it
-    # a string like "/foo", if there is a key named "/foo" it is served via the
-    # Gopher protocol.
-    #
-    # In order to create a real Gopher "hole" (the name of a Gopher site in Gopher
-    # talking), you likely need a script like the following:
-    #
-    #   https://github.com/antirez/gopher2redis
-    #
-    # --- SECURITY WARNING ---
-    #
-    # If you plan to put Redis on the internet in a publicly accessible address
-    # to server Gopher pages MAKE SURE TO SET A PASSWORD to the instance.
-    # Once a password is set:
-    #
-    #   1. The Gopher server (when enabled, not by default) will still serve
-    #      content via Gopher.
-    #   2. However other commands cannot be called before the client will
-    #      authenticate.
-    #
-    # So use the 'requirepass' option to protect your instance.
-    #
-    # To enable Gopher support uncomment the following line and set
-    # the option from no (the default) to yes.
-    #
-    # gopher-enabled no
-
     ############################### ADVANCED CONFIG ###############################
 
     # Hashes are encoded using a memory efficient data structure when they have a
     # small number of entries, and the biggest entry does not exceed a given
     # threshold. These thresholds can be configured using the following directives.
-    hash-max-ziplist-entries 512
-    hash-max-ziplist-value 64
+    hash-max-listpack-entries 512
+    hash-max-listpack-value 64
 
     # Lists are also encoded in a special way to save a lot of space.
     # The number of entries allowed per internal list node can be specified
@@ -1523,7 +1940,7 @@ data:
     # per list node.
     # The highest performing option is usually -2 (8 Kb size) or -1 (4 Kb size),
     # but if your use case is unique, adjust the settings as necessary.
-    list-max-ziplist-size -2
+    list-max-listpack-size -2
 
     # Lists may also be compressed.
     # Compress depth is the number of quicklist ziplist nodes from *each* side of
@@ -1551,8 +1968,8 @@ data:
     # Similarly to hashes and lists, sorted sets are also specially encoded in
     # order to save a lot of space. This encoding is only used when the length and
     # elements of a sorted set are below the following limits:
-    zset-max-ziplist-entries 128
-    zset-max-ziplist-value 64
+    zset-max-listpack-entries 128
+    zset-max-listpack-value 64
 
     # HyperLogLog sparse representation bytes limit. The limit includes the
     # 16 bytes header. When an HyperLogLog using the sparse representation crosses
@@ -1574,9 +1991,9 @@ data:
     # maximum number of items it may contain before switching to a new node when
     # appending new stream entries. If any of the following settings are set to
     # zero, the limit is ignored, so for instance it is possible to set just a
-    # max entires limit by setting max-bytes to 0 and max-entries to the desired
+    # max entries limit by setting max-bytes to 0 and max-entries to the desired
     # value.
-    stream-node-max-bytes 4kb
+    stream-node-max-bytes 4096
     stream-node-max-entries 100
 
     # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
@@ -1607,7 +2024,7 @@ data:
     # The limit can be set differently for the three different classes of clients:
     #
     # normal -> normal clients including MONITOR clients
-    # replica  -> replica clients
+    # replica -> replica clients
     # pubsub -> clients subscribed to at least one pubsub channel or pattern
     #
     # The syntax of every client-output-buffer-limit directive is the following:
@@ -1631,6 +2048,13 @@ data:
     # Instead there is a default limit for pubsub and replica clients, since
     # subscribers and replicas receive data in a push fashion.
     #
+    # Note that it doesn't make sense to set the replica clients output buffer
+    # limit lower than the repl-backlog-size config (partial sync will succeed
+    # and then replica will get disconnected).
+    # Such a configuration is ignored (the size of repl-backlog-size will be used).
+    # This doesn't have memory consumption implications since the replica client
+    # will share the backlog buffers memory.
+    #
     # Both the hard or the soft limit can be disabled by setting them to zero.
     client-output-buffer-limit normal 0 0 0
     client-output-buffer-limit replica 256mb 64mb 60
@@ -1644,9 +2068,28 @@ data:
     #
     # client-query-buffer-limit 1gb
 
+    # In some scenarios client connections can hog up memory leading to OOM
+    # errors or data eviction. To avoid this we can cap the accumulated memory
+    # used by all client connections (all pubsub and normal clients). Once we
+    # reach that limit connections will be dropped by the server freeing up
+    # memory. The server will attempt to drop the connections using the most 
+    # memory first. We call this mechanism "client eviction".
+    #
+    # Client eviction is configured using the maxmemory-clients setting as follows:
+    # 0 - client eviction is disabled (default)
+    #
+    # A memory value can be used for the client eviction threshold,
+    # for example:
+    # maxmemory-clients 1g
+    #
+    # A percentage value (between 1% and 100%) means the client eviction threshold
+    # is based on a percentage of the maxmemory setting. For example to set client
+    # eviction at 5% of maxmemory:
+    # maxmemory-clients 5%
+
     # In the Redis protocol, bulk requests, that are, elements representing single
-    # strings, are normally limited ot 512 mb. However you can change this limit
-    # here.
+    # strings, are normally limited to 512 mb. However you can change this limit
+    # here, but must be 1mb or greater
     #
     # proto-max-bulk-len 512mb
 
@@ -1674,7 +2117,7 @@ data:
     #
     # Since the default HZ value by default is conservatively set to 10, Redis
     # offers, and enables by default, the ability to use an adaptive HZ value
-    # which will temporary raise when there are many connected clients.
+    # which will temporarily raise when there are many connected clients.
     #
     # When dynamic HZ is enabled, the actual configured HZ will be used
     # as a baseline, but multiples of the configured HZ value will be actually
@@ -1684,13 +2127,13 @@ data:
     dynamic-hz yes
 
     # When a child rewrites the AOF file, if the following option is enabled
-    # the file will be fsync-ed every 32 MB of data generated. This is useful
+    # the file will be fsync-ed every 4 MB of data generated. This is useful
     # in order to commit the file to the disk more incrementally and avoid
     # big latency spikes.
     aof-rewrite-incremental-fsync yes
 
     # When redis saves RDB file, if the following option is enabled
-    # the file will be fsync-ed every 32 MB of data generated. This is useful
+    # the file will be fsync-ed every 4 MB of data generated. This is useful
     # in order to commit the file to the disk more incrementally and avoid
     # big latency spikes.
     rdb-save-incremental-fsync yes
@@ -1741,7 +2184,7 @@ data:
     # for the key counter to be divided by two (or decremented if it has a value
     # less <= 10).
     #
-    # The default value for the lfu-decay-time is 1. A Special value of 0 means to
+    # The default value for the lfu-decay-time is 1. A special value of 0 means to
     # decay the counter every time it happens to be scanned.
     #
     # lfu-log-factor 10
@@ -1761,7 +2204,7 @@ data:
     # restart is needed in order to lower the fragmentation, or at least to flush
     # away all the data and create it again. However thanks to this feature
     # implemented by Oran Agra for Redis 4.0 this process can happen at runtime
-    # in an "hot" way, while the server is running.
+    # in a "hot" way, while the server is running.
     #
     # Basically when the fragmentation is over a certain level (see the
     # configuration options below) Redis will start to create new copies of the
@@ -1787,7 +2230,7 @@ data:
     # defragmentation process. If you are not sure about what they mean it is
     # a good idea to leave the defaults untouched.
 
-    # Enabled active defragmentation
+    # Active defragmentation is disabled by default
     # activedefrag no
 
     # Minimum amount of fragmentation waste to start active defrag
@@ -1838,4 +2281,10 @@ data:
     #
     # Set bgsave child process to cpu affinity 1,10,11
     # bgsave_cpulist 1,10-11
-    # Generated by CONFIG REWRITE
+
+    # In some cases redis will emit warnings and even refuse to start if it detects
+    # that the system is in bad state, it is possible to suppress these warnings
+    # by setting the following config which takes a space delimited list of warnings
+    # to suppress
+    #
+    # ignore-warnings ARM64-COW-BUG

--- a/storage/redis/kubernetes/redis/redis-statefulset.yaml
+++ b/storage/redis/kubernetes/redis/redis-statefulset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       initContainers:
       - name: config
-        image: redis:6.2.3-alpine
+        image: redis:7.0.10-alpine
         command: [ "sh", "-c" ]
         args:
           - |
@@ -30,13 +30,13 @@ spec:
                 echo "this is redis-0, not updating config..."
               else
                 echo "updating redis.conf..."
-                echo "slaveof $MASTER_FDQN 6379" >> /etc/redis/redis.conf
+                echo "replicaof $MASTER_FDQN 6379" >> /etc/redis/redis.conf
               fi
             else
               echo "sentinel found, finding master"
               MASTER="$(redis-cli -h sentinel -p 5000 sentinel get-master-addr-by-name mymaster | grep -E '(^redis-\d{1,})|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})')"
               echo "master found : $MASTER, updating redis.conf"
-              echo "slaveof $MASTER 6379" >> /etc/redis/redis.conf
+              echo "replicaof $MASTER 6379" >> /etc/redis/redis.conf
             fi
         volumeMounts:
         - name: redis-config
@@ -45,7 +45,7 @@ spec:
           mountPath: /tmp/redis/
       containers:
       - name: redis
-        image: redis:6.2.3-alpine
+        image: redis:7.0.10-alpine
         command: ["redis-server"]
         args: ["/etc/redis/redis.conf"]
         ports:
@@ -70,7 +70,7 @@ spec:
       storageClassName: "standard"
       resources:
         requests:
-          storage: 50Mi
+          storage: 64Mi
 ---
 apiVersion: v1
 kind: Service

--- a/storage/redis/kubernetes/sentinel/sentinel-statefulset.yaml
+++ b/storage/redis/kubernetes/sentinel/sentinel-statefulset.yaml
@@ -15,14 +15,15 @@ spec:
     spec:
       initContainers:
       - name: config
-        image: redis:6.2.3-alpine
+        image: redis:7.0.10-alpine
         command: [ "sh", "-c" ]
         args:
           - |
             REDIS_PASSWORD=a-very-complex-password-here
             nodes=redis-0.redis,redis-1.redis,redis-2.redis
+            loop=$(echo $nodes | sed -e "s/,/\n/g")
 
-            for i in ${nodes//,/ }
+            for i in $loop
             do
                 echo "finding master at $i"
                 MASTER=$(redis-cli --no-auth-warning --raw -h $i -a $REDIS_PASSWORD info replication | awk '{print $1}' | grep master_host: | cut -d ":" -f2)
@@ -50,7 +51,7 @@ spec:
           mountPath: /etc/redis/
       containers:
       - name: sentinel
-        image: redis:6.2.3-alpine
+        image: redis:7.0.10-alpine
         command: ["redis-sentinel"]
         args: ["/etc/redis/sentinel.conf"]
         ports:
@@ -72,7 +73,7 @@ spec:
       storageClassName: "standard"
       resources:
         requests:
-          storage: 50Mi
+          storage: 64Mi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR fixes the Redis-Kubernetes portion of this repo.

Because normal sh does not support bash string modifications, a workaround with a helper var is needed to loop over the supplied hostnames. I also threw an update of redis to the latest alpine version into the mix 👌.

**Related:**

- I guess my fork 🤔 https://github.com/DerLev/redis-kubernetes-fix

**Fixes:**

- Error in the Init Container of the sentinel StatefulSet