### PR TITLE
FIX: Can't open the append-only file: Permission denied

### DIFF
--- a/kubernetes/servicemesh/docker-compose.yaml
+++ b/kubernetes/servicemesh/docker-compose.yaml
@@ -32,12 +32,14 @@ services:
   videos-db:
     container_name: videos-db
     image: redis:6.0-alpine
+    user: "1000:1000"
     command: [ "redis-server" , "--dir", "/tmp", "--appendonly", "yes"]
     volumes:
       - ./applications/videos-db/appendonly.aof:/tmp/appendonly.aof
   playlists-db:
     container_name: playlists-db
     image: redis:6.0-alpine
+    user: "1000:1000"
     command: [ "redis-server" , "--dir", "/tmp", "--appendonly", "yes"]
     volumes:
       - ./applications/playlists-db/appendonly.aof:/tmp/appendonly.aof


### PR DESCRIPTION
playlists-db  and videos-db containers exit  while running the containers locally
```Can't open the append-only file: Permission denied``` error is thrown