### PR TITLE
bump cluster role binding

### DIFF
--- a/kubernetes/ingress/controller/nginx/cluster-role-binding.yaml
+++ b/kubernetes/ingress/controller/nginx/cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nginx-ingress-clusterrole-nisa-binding
@@ -10,3 +10,4 @@ subjects:
   - kind: ServiceAccount
     name: nginx-ingress-serviceaccount
     namespace: ingress-nginx
+


### PR DESCRIPTION
no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"

Client Version: v1.30.0
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Server Version: v1.30.0