### PR TITLE
Fixing deprecated annotations and parameters

### DIFF
--- a/kubernetes/servicemesh/applications/playlists-api/deploy.yaml
+++ b/kubernetes/servicemesh/applications/playlists-api/deploy.yaml
@@ -49,11 +49,11 @@ spec:
       port: 80
       targetPort: 10010
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/spec.ingressClassName: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
   name: playlists-api
@@ -63,8 +63,11 @@ spec:
     http:
       paths:
       - path: /api/playlists(/|$)(.*)
+        pathType: ImplementationSpecific
         backend:
-          serviceName: playlists-api
-          servicePort: 80
+          service:
+            name: playlists-api
+            port:
+              number: 80
 
 

--- a/kubernetes/servicemesh/applications/videos-web/deploy.yaml
+++ b/kubernetes/servicemesh/applications/videos-web/deploy.yaml
@@ -42,11 +42,11 @@ spec:
       port: 80
       targetPort: 80
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/spec.ingressClassName: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
   name: videos-web
@@ -56,7 +56,10 @@ spec:
     http:
       paths:
       - path: /home(/|$)(.*)
+        pathType: ImplementationSpecific
         backend:
-          serviceName: videos-web
-          servicePort: 80
+          service:
+            name: videos-web
+            port: 
+              number: 80
 


### PR DESCRIPTION
Fixing the following errors while trying to deploy with the deploy.yaml files:

kubectl apply -f applications/videos-web/deploy.yaml
error: resource mapping not found for name: "videos-web" namespace: "" from "applications/videos-web/deploy.yaml": no matches for kind "Ingress" in version "networking.k8s.io/v1beta1"
ensure CRDs are installed first

Error from server (BadRequest): error when creating "applications/videos-web/deploy.yaml": Ingress in version "v1" cannot be handled as a Ingress: strict decoding error: unknown field "spec.rules[0].http.paths[0].backend.serviceName", unknown field "spec.rules[0].http.paths[0].backend.servicePort"

Error from server (BadRequest): error when creating "applications/videos-web/deploy.yaml": Ingress in version "v1" cannot be handled as a Ingress: strict decoding error: unknown field "spec.rules[0].http.paths[0].backend.name", unknown field "spec.rules[0].http.paths[0].backend.port"

The Ingress "videos-web" is invalid: spec.rules[0].http.paths[0].pathType: Required value: pathType must be specified

Warning: annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
Warning: path /home(/|$)(.*) cannot be used with pathType Prefix



