### PR TITLE
Fix actions-runner ownership

### DIFF
--- a/github/actions/self-hosted-runner/dockerfile
+++ b/github/actions/self-hosted-runner/dockerfile
@@ -32,8 +32,11 @@ RUN useradd -m github && \
   usermod -aG sudo github && \
   echo "%sudo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-USER github
+
 WORKDIR /actions-runner
+RUN chown github .
+USER github
+
 RUN curl -Ls https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz | tar xz \
   && sudo ./bin/installdependencies.sh
 


### PR DESCRIPTION
Ensure that github user owns actions-runner dir.

Found that when building image github user was unable to store runner tar.gz file as it had no owner rights to the actions-runner dir